### PR TITLE
Fix a breaking typo in zonecfg module

### DIFF
--- a/salt/modules/zonecfg.py
+++ b/salt/modules/zonecfg.py
@@ -57,7 +57,7 @@ _zonecfg_info_resources_calculated = [
 
 _zonecfg_resource_setters = {
     'fs': ['dir', 'special', 'raw', 'type', 'options'],
-    'net': ['address', 'allowed-address', 'global-nic', 'mac-addr', 'physical', 'property', 'vlan-id defrouter'],
+    'net': ['address', 'allowed-address', 'global-nic', 'mac-addr', 'physical', 'property', 'vlan-id', 'defrouter'],
     'device': ['match', 'property'],
     'rctl': ['name', 'value'],
     'attr': ['name', 'type', 'value'],


### PR DESCRIPTION
The zone net resource properties vlan-id and defrouter were unintentionally combined into a single array element, which prevented Salt from setting either of those properties on Solaris Zones.  This commit splits them into their correct seperate elements and allows Salt to set the properties.